### PR TITLE
Make doctests strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Updated all the examples to go with `Julia v1.7.2` migration ([#34](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/34), @Saransh-cpp)
 - All the docstrings have been updated to follow `Julia v1.7.2` and to pass the `doctests` ([#32](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/32), @Saransh-cpp)
 
+## CI
+- Doctests now fail on encountering an error ([#40](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/40), @Saransh-cpp)
+
 # ChaoticEncryption v0.1.1
 
 ## Documentation

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,8 @@ using ChaoticEncryption
 makedocs(
     sitename = "ChaoticEncryption",
     format = Documenter.HTML(sidebar_sitename=false),
-    modules = [ChaoticEncryption]
+    modules = [ChaoticEncryption],
+    strict = true
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.


### PR DESCRIPTION
# Description

The `Documentation` CI will now fail if the doctests don't pass.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/Saransh-cpp/ChaoticEncryption.jl/blob/v0.1.0/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] Package installs: `julia> ]dev .`
- [X] All tests pass: `julia> ]test ChaoticEncryption`
- [X] The documentation builds: `$ cd docs` and then `$ julia make.jl`


## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works

### Acknowledgements
This Pull Request template was taken from the excellent [PyBaMM](https://github.com/pybamm-team/PyBaMM) repository.
