### PR TITLE
Pre-allocate memory in `logistic_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## Features
 - `lorenz_key` and `logistic_key` are more flexible and independent now (one can specify the upper bound of pseudo-random number, hence now they are not limited only to image encryption) ([#39](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/39), @Saransh-cpp)
 
+## Optimisations
+- `logistic_key` now pre-allocates the memory, making the function twice as fast as before ([#48](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/48), @Saransh-cpp)
+
 ## Documentation
 - Updated all the examples to go with `Julia v1.7.2` migration ([#34](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/34), @Saransh-cpp)
 - All the docstrings have been updated to follow `Julia v1.7.2` and to pass the `doctests` ([#32](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/32), @Saransh-cpp)

--- a/src/logistic_key.jl
+++ b/src/logistic_key.jl
@@ -54,13 +54,13 @@ function logistic_key(
     scaling_factor::Float64=10.0^16,
     upper_bound::Float64=256.0
 )
-    keys = Vector{Int64}()
+    keys = Vector{Int64}(undef, num_keys)
     x = x_init
 
     for i = 1:num_keys
         x = r * x * (1 - x)
         key = x * scaling_factor % upper_bound
-        push!(keys, trunc(Int, key))
+        keys[i] = trunc(Int, key)
     end
 
     return keys


### PR DESCRIPTION
# Description

Pre-allocate memory in `logistic_key` to make the function call twice as fast as before!

## Before
```julia
julia> include("./src/logistic_key.jl")
BenchmarkTools.Trial: 10000 samples with 162 evaluations.
 Range (min … max):  319.136 ns …  19.333 μs  ┊ GC (min … max): 0.00% … 94.60%
 Time  (median):     546.296 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   594.358 ns ± 637.921 ns  ┊ GC (mean ± σ):  4.23% ±  3.96%

  ▄▁ ▇▁ ▂   ▅▂   ▆▅     ▄█▄▂     ▁▂▂               ▃▃           ▂
  █████▅█▇▅▅██▇▇▅███▄▄▆▄█████▇▆▅▅███▇▆▅▆▃▆▆██▆▄▄▂▄▄██▄▆▆▆▅▇▅▆▇▆ █
  319 ns        Histogram: log(frequency) by time       1.13 μs <

 Memory estimate: 480 bytes, allocs estimate: 3.
```

## Now
```julia
julia> include("./src/logistic_key.jl")
BenchmarkTools.Trial: 10000 samples with 600 evaluations.
 Range (min … max):  201.500 ns …  3.136 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     239.000 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   249.455 ns ± 70.483 ns  ┊ GC (mean ± σ):  0.78% ± 3.88%

    █▃▂   ▆ ▂    ▇▂   ▂
  ▁▇████▂▃█▃█▃▄▃▅██▂▅▃█▂▂▂▁▁▁▁▂▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  202 ns          Histogram: frequency by time          420 ns <

 Memory estimate: 224 bytes, allocs estimate: 1.
```

Fixes #44

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/Saransh-cpp/ChaoticEncryption.jl/blob/v0.1.0/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [X] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] Package installs: `julia> ]dev .`
- [X] All tests pass: `julia> ]test ChaoticEncryption`
- [X] The documentation builds: `$ cd docs` and then `$ julia make.jl`


## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works

### Acknowledgements
This Pull Request template was taken from the excellent [PyBaMM](https://github.com/pybamm-team/PyBaMM) repository.
