### PR TITLE
Introduce `save_img`, `debug`, and add `!` to `_substitute_pixel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Features
 
--  Introduced `save_img` argument in encryption/decryption functions to manually save the resultant image
--  Introduced `debug` argument in encryption/decryption functions to print debug statements
+-  Introduced `save_img` argument in encryption/decryption functions to manually save the resultant image ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+-  Introduced `debug` argument in encryption/decryption functions to print debug statements ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 ## Bug fixes
 
--  Renamed `_substitute_pixel` to `_substitute_pixel!` to show the inplace alterations
+-  Renamed `_substitute_pixel` to `_substitute_pixel!` to show the inplace alterations ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 ## Optimisations
 
--  Added `Bool` type to the `inplace` variable
+-  Added `Bool` type to the `inplace` variable ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 # ChaoticEncryption v0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+## Features
+
+-  Introduced `save_img` argument in encryption/decryption functions to manually save the resultant image
+-  Introduced `debug` argument in encryption/decryption functions to print debug statements
+
+## Bug fixes
+
+-  Renamed `_substitute_pixel` to `_substitute_pixel!` to show the inplace alterations
+
+## Optimisations
+
+-  Added `Bool` type to the `inplace` variable
+
 # ChaoticEncryption v0.3.2
 
 ## Optimisations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 -  Added `Bool` type to the `inplace` variable ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
+## Documentation
+
+-  Made everything strict except `:missing docs` ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+
 # ChaoticEncryption v0.3.2
 
 ## Optimisations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,20 @@
 
 ## Features
 
--  Introduced `save_img` argument in encryption/decryption functions to manually save the resultant image ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
--  Introduced `debug` argument in encryption/decryption functions to print debug statements ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+-   Introduced `save_img` argument in encryption/decryption functions to manually save the resultant image ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+-   Introduced `debug` argument in encryption/decryption functions to print debug statements ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 ## Bug fixes
 
--  Renamed `_substitute_pixel` to `_substitute_pixel!` to show the inplace alterations ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+-   Renamed `_substitute_pixel` to `_substitute_pixel!` to show the inplace alterations ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 ## Optimisations
 
--  Added `Bool` type to the `inplace` variable ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+-   Added `Bool` type to the `inplace` variable ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 ## Documentation
 
--  Made everything strict except `:missing docs` ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
+-   Made everything strict except `:missing docs` ([#83](https://github.com/Saransh-cpp/ChaoticEncryption.jl/pull/83))
 
 # ChaoticEncryption v0.3.2
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ makedocs(
     format = Documenter.HTML(sidebar_sitename=false),
     modules = [ChaoticEncryption, Images, TestImages],
     doctest = true,
-    strict = :doctest,
+    strict = Documenter.except(:missing_docs),
     pages = [
         "Home" => "index.md",
         "Tutorials" => [

--- a/docs/src/apidocs/algorithms.md
+++ b/docs/src/apidocs/algorithms.md
@@ -7,16 +7,20 @@
 ```@docs
 substitution_encryption(
     image::Array{RGB{N0f8},2},
-    keys::Array{Int64, 1};
-    path_for_result::String="./encrypted.png"
+    keys::Vector{Int64};
+    save_img::Bool=false,
+    path_for_result::String="./encrypted.png",
+    debug::Bool=false,
 )
 ```
 
 ```@docs
 substitution_encryption!(
     image::Array{RGB{N0f8},2},
-    keys::Array{Int64, 1};
-    path_for_result::String="./encrypted.png"
+    keys::Vector{Int64};
+    save_img::Bool=false,
+    path_for_result::String="./encrypted.png",
+    debug::Bool=false,
 )
 ```
 
@@ -25,15 +29,19 @@ substitution_encryption!(
 ```@docs
 substitution_decryption(
     image::Union{String,Array{RGB{N0f8},2}},
-    keys::Array{Int64, 1};
-    path_for_result::String="./decrypted.png"
+    keys::Vector{Int64};
+    save_img::Bool=false,
+    path_for_result::String="./decrypted.png",
+    debug::Bool=false
 )
 ```
 
 ```@docs
 substitution_decryption!(
     image::Array{RGB{N0f8},2},
-    keys::Array{Int64, 1};
-    path_for_result::String="./decrypted.png"
+    keys::Vector{Int64};
+    save_img::Bool=false,
+    path_for_result::String="./decrypted.png",
+    debug::Bool=false,
 )
 ```

--- a/docs/src/devdocs/algorithms.md
+++ b/docs/src/devdocs/algorithms.md
@@ -13,10 +13,7 @@ ChaoticEncryption._substitution(
     path_for_result::String="./encrypted.png",
     inplace=false,
 )
-```
-
-```@docs
-ChaoticEncryption._substitute_pixel(
+ChaoticEncryption._substitute_pixel!(
     pixel::RGB,
     key::Int64
 )

--- a/docs/src/devdocs/algorithms.md
+++ b/docs/src/devdocs/algorithms.md
@@ -10,8 +10,10 @@ ChaoticEncryption._substitution(
     image::Union{String,Array{RGB{N0f8},2}},
     keys::Vector{Int64},
     type::Symbol;
+    save::Bool=false,
     path_for_result::String="./encrypted.png",
-    inplace=false,
+    inplace::Bool=false,
+    debug::Bool=false
 )
 ChaoticEncryption._substitute_pixel!(
     pixel::RGB,

--- a/src/substitution.jl
+++ b/src/substitution.jl
@@ -12,22 +12,28 @@ See [`substitution_encryption`](@ref) and [`substitution_decryption`](@ref) for 
 - `image::Array{RGB{N0f8},2}`: A loaded image.
 - `keys::Array{Int64, 1}`: Keys for encryption.
 - `type::Symbol`: Can be `:encrypt` or `:decrypt`.
+- `save_img::Bool=false`: Save the resultant image.
 - `path_for_result::String`: The path for storing the encrypted image.
-- `inplace::Boolean`: Perform substitution on the provided image.
+- `inplace::Bool`: Perform substitution on the provided image.
+- `debug::Bool`: Print debug output.
 """
 function _substitution(
     image::Union{String,Array{RGB{N0f8},2}},
     keys::Vector{Int64},
     type::Symbol;
+    save_img::Bool=false,
     path_for_result::String="./encrypted.png",
-    inplace=false,
+    inplace::Bool=false,
+    debug::Bool=false,
 )
 
+    debug && @info "Loading image from path"
     if typeof(image) == String
         image = load(image)
     end
 
     # Generating dimensions of the image
+    debug && @info "Generating dimensions"
     height = size(image)[1]
     width = size(image)[2]
 
@@ -36,33 +42,41 @@ function _substitution(
     end
 
     # generate a copy if not inplace
+    debug && "Generating a copy of the image"
     ~inplace && (image = copy(image))
 
-    if type == :encrypt
-        @info "ENCRYPTING"
-    else
-        @info "DECRYPTING"
+    if debug
+        if type == :encrypt
+            @info "ENCRYPTING"
+        elseif type == :decrypt
+            @info "DECRYPTING"
+        end
     end
 
     # reshape keys for broadcasting
+    debug && @info "Reshaping keys for broadcasting"
     keys = reshape(keys, height, width)
 
     # substitute all pixels in one go
-    @. image = _substitute_pixel(image, keys)
+    debug && @info "Substituting all pixels"
+    @. image = _substitute_pixel!(image, keys)
 
-    if type == :encrypt
-        @info "ENCRYPTED"
-    else
-        @info "DECRYPTED"
+    if debug
+        if type == :encrypt
+            @info "ENCRYPTED"
+        elseif type == :decrypt
+            @info "DECRYPTED"
+        end
     end
 
-    save(path_for_result, image)
+    debug && @info "Saving result"
+    save_img && save(path_for_result, image)
     image
 end
 
 
 """
-    _substitute_pixel(pixel::RGB, key::Int64)
+    _substitute_pixel!(pixel::RGB, key::Int64)
 
 Returns the pixel after XORing the R, G, and B values with the key.
 Specifically developed to return an `Array` (or the complete image)
@@ -77,7 +91,7 @@ See [`_substitution`](@ref) for more details.
 # Returns
 - `pixel::RGB`: Substituted pixel.
 """
-_substitute_pixel(pixel::RGB, key::Int64) = RGB(
+_substitute_pixel!(pixel::RGB, key::Int64) = RGB(
     (trunc(Int, pixel.r * 255) ⊻ key) / 255,
     (trunc(Int, pixel.g * 255) ⊻ key) / 255,
     (trunc(Int, pixel.b * 255) ⊻ key) / 255
@@ -96,7 +110,9 @@ Iterates simulataneously over each pixel and key, and XORs the pixel value
 # Arguments
 - `image::Array{RGB{N0f8},2}`: A loaded image.
 - `keys::Array{Int64, 1}`: Keys for encryption.
+- `save_img::Bool=false`: Save the resultant image.
 - `path_for_result::String`: The path for storing the encrypted image.
+- `debug::Bool`: Print debug output.
 
 # Returns
 - `image::Array{RGB{N0f8}, 2}`: Encrypted image.
@@ -129,8 +145,17 @@ true
 substitution_encryption(
     image::Array{RGB{N0f8},2},
     keys::Vector{Int64};
-    path_for_result::String="./encrypted.png"
-) = _substitution(image, keys, :encrypt; path_for_result=path_for_result)
+    save_img::Bool=false,
+    path_for_result::String="./encrypted.png",
+    debug::Bool=false,
+) = _substitution(
+    image,
+    keys,
+    :encrypt;
+    save_img=save_img,
+    path_for_result=path_for_result,
+    debug=debug,
+)
 
 
 """
@@ -145,7 +170,9 @@ Iterates simulataneously over each pixel and key, and XORs the pixel value
 # Arguments
 - `image::Array{RGB{N0f8},2}`: A loaded image.
 - `keys::Array{Int64, 1}`: Keys for encryption.
+- `save_img::Bool=false`: Save the resultant image.
 - `path_for_result::String`: The path for storing the encrypted image.
+- `debug::Bool`: Print debug output.
 
 # Returns
 - `image::Array{RGB{N0f8}, 2}`: Encrypted image.
@@ -177,8 +204,18 @@ true
 substitution_encryption!(
     image::Array{RGB{N0f8},2},
     keys::Vector{Int64};
-    path_for_result::String="./encrypted.png"
-) = _substitution(image, keys, :encrypt; path_for_result=path_for_result, inplace=true)
+    save_img::Bool=false,
+    path_for_result::String="./encrypted.png",
+    debug::Bool=false,
+) = _substitution(
+    image,
+    keys,
+    :encrypt;
+    save_img=save_img,
+    path_for_result=path_for_result,
+    inplace=true,
+    debug=false,
+)
 
 
 """
@@ -194,7 +231,9 @@ as the ones provided during encryption.
 # Arguments
 - `image::Union{String,Array{RGB{N0f8},2}}`: The path to the image or the loaded image to be decrypted.
 - `keys::Array{Int64, 1}`: Keys for decryption.
-- `path_for_result::String`: The path for storing the decrypted image.
+- `save_img::Bool=false`: Save the resultant image.
+- `path_for_result::String`: The path for storing the encrypted image.
+- `debug::Bool`: Print debug output.
 
 # Returns
 - `image::Array{RGB{N0f8}, 2}`: Decrypted image.
@@ -227,8 +266,17 @@ true
 substitution_decryption(
     image::Union{String,Array{RGB{N0f8},2}},
     keys::Vector{Int64};
+    save_img::Bool=false,
     path_for_result::String="./decrypted.png",
-) = _substitution(image, keys, :decrypt; path_for_result=path_for_result)
+    debug::Bool=false
+) = _substitution(
+    image,
+    keys,
+    :decrypt;
+    save_img=save_img,
+    path_for_result=path_for_result,
+    debug=debug,
+)
 
 
 """
@@ -244,7 +292,9 @@ as the ones provided during encryption.
 # Arguments
 - `image::Union{String,Array{RGB{N0f8},2}}`: The path to the image or the loaded image to be decrypted.
 - `keys::Array{Int64, 1}`: Keys for decryption.
-- `path_for_result::String`: The path for storing the decrypted image.
+- `save_img::Bool=false`: Save the resultant image.
+- `path_for_result::String`: The path for storing the encrypted image.
+- `debug::Bool`: Print debug output.
 
 # Returns
 - `image::Array{RGB{N0f8}, 2}`: Decrypted image.
@@ -276,5 +326,15 @@ true
 substitution_decryption!(
     image::Array{RGB{N0f8},2},
     keys::Vector{Int64};
+    save_img::Bool=false,
     path_for_result::String="./decrypted.png",
-) = _substitution(image, keys, :decrypt; path_for_result=path_for_result, inplace=true)
+    debug::Bool=false,
+) = _substitution(
+    image,
+    keys,
+    :decrypt;
+    save_img=save_img,
+    path_for_result=path_for_result,
+    inplace=true,
+    debug=debug,
+)

--- a/src/substitution.jl
+++ b/src/substitution.jl
@@ -132,8 +132,6 @@ julia> keys |> size
 (262144,)
 
 julia> enc = substitution_encryption(img, keys);
-[ Info: ENCRYPTING
-[ Info: ENCRYPTED
 
 julia> enc |> size
 (512, 512)
@@ -194,8 +192,6 @@ julia> keys |> size
 julia> orig = copy(img);
 
 julia> substitution_encryption!(img, keys);
-[ Info: ENCRYPTING
-[ Info: ENCRYPTED
 
 julia> img != orig  # inplace
 true
@@ -253,8 +249,6 @@ julia> keys |> size
 (262144,)
 
 julia> dec = substitution_decryption(img, keys);
-[ Info: DECRYPTING
-[ Info: DECRYPTED
 
 julia> dec |> size
 (512, 512)
@@ -316,8 +310,6 @@ julia> keys |> size
 julia> orig = copy(img);
 
 julia> substitution_decryption!(img, keys);
-[ Info: DECRYPTING
-[ Info: DECRYPTED
 
 julia> img != orig  # inplace
 true

--- a/test/test_chaotic_encryption.jl
+++ b/test/test_chaotic_encryption.jl
@@ -22,7 +22,7 @@ using Test
         height, width = size(img)
         keys = logistic_key(0.01, 3.97, height * width)
 
-        substitution_encryption(img, keys; path_for_result="../test_images/encrypted.png")
+        substitution_encryption(img, keys; save_img=true, path_for_result="../test_images/encrypted.png", debug=true)
         @test isfile("../test_images/encrypted.png")
 
         keys = logistic_key(0.01, 3.97, 20)
@@ -34,7 +34,7 @@ using Test
         height, width = size(img)
         keys = logistic_key(0.01, 3.97, height * width)
 
-        enc = substitution_encryption!(img, keys; path_for_result="../test_images/encrypted.png")
+        enc = substitution_encryption!(img, keys; save_img=true, path_for_result="../test_images/encrypted.png", debug=true)
         @test isfile("../test_images/encrypted.png")
         @test img == enc  # inplace
     end
@@ -44,10 +44,10 @@ using Test
         height, width = size(img)
         keys = logistic_key(0.01, 3.97, height * width)
 
-        substitution_decryption("../test_images/encrypted.png", keys; path_for_result="../test_images/decrypted.png")
+        substitution_decryption("../test_images/encrypted.png", keys; save_img=true, path_for_result="../test_images/decrypted.png", debug=true)
         @test isfile("../test_images/decrypted.png")
 
-        substitution_decryption(img, keys; path_for_result="../test_images/decrypted.png")
+        substitution_decryption(img, keys; save_img=true, path_for_result="../test_images/decrypted.png", debug=true)
         @test isfile("../test_images/decrypted.png")
 
         keys = logistic_key(0.01, 3.97, 20)
@@ -62,7 +62,7 @@ using Test
         height, width = size(img)
         keys = logistic_key(0.01, 3.97, height * width)
 
-        dec = substitution_decryption!(img, keys; path_for_result="../test_images/decrypted.png")
+        dec = substitution_decryption!(img, keys; save_img=true, path_for_result="../test_images/decrypted.png", debug=true)
         @test isfile("../test_images/decrypted.png")
         @test img == dec  # inplace
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/Saransh-cpp/ChaoticEncryption.jl/blob/v0.1.0/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] Package installs: `julia> ]dev .`
- [ ] All tests pass: `julia> ]test ChaoticEncryption`
- [ ] The documentation builds: `$ cd docs` and then `$ julia make.jl`


## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works

### Acknowledgements
This Pull Request template was taken from the excellent [PyBaMM](https://github.com/pybamm-team/PyBaMM) repository.
